### PR TITLE
Added `^C` trigger to commands. May break existing code that isn't reworked.

### DIFF
--- a/commands/command.go
+++ b/commands/command.go
@@ -5,11 +5,13 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
+	"os"
+	"os/signal"
 )
 
 type Command interface {
 	GetName() string
-	Execute(args []string)
+	Execute(kill chan bool, args []string)
 }
 
 var commands []Command
@@ -31,10 +33,21 @@ func RunCommand(cmd string) {
 	if element == nil {
 		fmt.Fprintln(color.Output, "Cannot resolve this command. Type "+color.YellowString("help")+" for a help gui")
 	} else {
-		element.Execute(append(args[:0], args[0+1:]...))
+		RunCommandAsync(element, args)
 	}
 }
 
+func RunCommandAsync(command Command, args []string) {
+	kill := make(chan bool, 1)
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt)
+	go func() {
+		for range signals {
+			kill <- true
+		}
+	}()
+	command.Execute(kill, args[1:])
+}
 func getElementByString(cmd string) Command {
 	for _, element := range commands {
 		if strings.EqualFold(element.GetName(), cmd) {

--- a/commands/exit_command.go
+++ b/commands/exit_command.go
@@ -18,7 +18,7 @@ func (command ExitCommand) String() string {
 	return "<Command 'exit'>"
 }
 
-func (command ExitCommand) Execute(args []string) {
+func (command ExitCommand) Execute(kill chan bool, args []string) {
 	fmt.Println("See You later Alligator")
 	time.Sleep(2 * time.Second)
 	os.Exit(0)

--- a/commands/hackimitate_command.go
+++ b/commands/hackimitate_command.go
@@ -24,7 +24,7 @@ func (command HackImitateCommand) String() string {
 	return "<Command 'hackimitate'>"
 }
 
-func (command HackImitateCommand) Execute(args []string) {
+func (command HackImitateCommand) Execute(kill chan bool, args []string) {
 	fmt.Println("Its " + strconv.Itoa(time.Now().Day()) + "." + time.Now().Month().String() + "." + strconv.Itoa(time.Now().Year()))
 	time.Sleep(1 * time.Second)
 	fmt.Println("Starting hacking now...")

--- a/commands/help_command.go
+++ b/commands/help_command.go
@@ -17,7 +17,7 @@ func (command HelpCommand) String() string {
 	return "<Command 'help'>"
 }
 
-func (command HelpCommand) Execute(args []string) {
+func (command HelpCommand) Execute(kill chan bool, args []string) {
 	fmt.Println("HELP")
 	for i, element := range commands {
 		fmt.Println(strconv.Itoa(i) + ":" + element.GetName())

--- a/commands/listFiles_command.go
+++ b/commands/listFiles_command.go
@@ -22,7 +22,7 @@ func (command ListFilesCommand) String() string {
 	return "<Command 'listFiles'>"
 }
 
-func (command ListFilesCommand) Execute(args []string) {
+func (command ListFilesCommand) Execute(kill chan bool, args []string) {
 	dir := ""
 	if len(args) > 0 {
 		dir = strings.Join(args, " ")

--- a/commands/portScan_command.go
+++ b/commands/portScan_command.go
@@ -20,7 +20,7 @@ func (command PortScanCommand) String() string {
 	return "<Command 'portscan'>"
 }
 
-func (command PortScanCommand) Execute(args []string) {
+func (command PortScanCommand) Execute(kill chan bool, args []string) {
 	if len(args) < 3 {
 		fmt.Println("portscan <address> <port-from> <port-to>")
 	}

--- a/commands/shell_command.go
+++ b/commands/shell_command.go
@@ -18,7 +18,7 @@ func (command ShellCommand) String() string {
 	return "<Command 'shell'>"
 }
 
-func (command ShellCommand) Execute(args []string) {
+func (command ShellCommand) Execute(kill chan bool, args []string) {
 	if len(args) < 1 {
 		fmt.Println("Missing arguments.")
 		return

--- a/commands/whois_command.go
+++ b/commands/whois_command.go
@@ -18,7 +18,7 @@ func (command WhoisCommand) String() string {
 	return "<Command 'whois'>"
 }
 
-func (command WhoisCommand) Execute(args []string) {
+func (command WhoisCommand) Execute(kill chan bool, args []string) {
 	if len(args) < 2 {
 		fmt.Println(fmt.Sprintf("usage:\n\t%s domain [server]", args[0]))
 		return


### PR DESCRIPTION
Quick fix: add `kill chan bool, ` to the existing parameter list of every not reworked command. Pull from that channel everytime you run a loop in the following fashion 
```
for {
    select {
        case <- kill:
            cleanup()
            return
        default:
            runOneLoopIteration()
    }
}
```